### PR TITLE
A promise cannot be completed 2x now

### DIFF
--- a/src/test/kotlin/com/shopify/promises/BasicPromiseTestCase.kt
+++ b/src/test/kotlin/com/shopify/promises/BasicPromiseTestCase.kt
@@ -304,6 +304,15 @@ class BasicPromiseTestCase {
     ).validateError(error)
   }
 
+  @Test(expected = IllegalStateException::class) fun resolve_multiple_times() {
+    val promise = Promise<String, RuntimeException> {
+      resolve("first")
+      resolve("second")
+    }
+
+    promise.whenComplete { }
+  }
+
   private fun <T, T1, E> Promise<T, E>.validateMap(expected: T, transform: (T) -> T1): Promise<T1, E> {
     return map {
       assertThat(it).isEqualTo(expected)


### PR DESCRIPTION
### What

Found an issue where if you somehow resolve a promise 2x, the second resolution ends up getting silently ignored as a no-op.
Fixed it such that the second resolution will now cause an `IllegalStateException`.

### How

`Promise::complete` now thoroughly checks for the old state, and only early returns if the old state was `Cancelled`. Resolving an `Idle` or `Complete`-ed promise leads to `IllegalStateException`.

Also added a test that exercises the buggy code path.